### PR TITLE
Preload download images

### DIFF
--- a/js/default.js
+++ b/js/default.js
@@ -9,4 +9,12 @@ $(document).ready(function() {
     e.preventDefault();
   });
 
+  var preloader = function (images) {
+    var i, image;
+    for (i = 0; i < images.length; i++) {
+      image = new Image();
+      image.src = images[i];
+    }
+  };
+
 });

--- a/js/default.js
+++ b/js/default.js
@@ -16,5 +16,12 @@ $(document).ready(function() {
       image.src = images[i];
     }
   };
+ 
+  preloader([
+    "/images/linux32.png",
+    "/images/linux64.png",
+    "/images/osx.png",
+    "/images/windows.png"
+  ]);
 
 });


### PR DESCRIPTION
I added some JavaScript to preload the images that show up when you click on the 'download' button prior to someone clicking on the button.  I think this will improve the user experience of the site since it can be pretty jarring clicking on the download button and not having anything show up until after a delay (even on a fast internet connection).

Thanks,
Brian
