### PR TITLE
Add blog post about new PHP plugin, upcoming v0.8.0 (alpha) release, and the future of LT development

### DIFF
--- a/_posts/2015-10-4-php-light-table-080-and-the-future-of-lt.markdown
+++ b/_posts/2015-10-4-php-light-table-080-and-the-future-of-lt.markdown
@@ -1,0 +1,30 @@
+---
+layout: post
+title: "PHP, Light Table 0.8.0 (alpha), and The Future of Light Table"
+author: Kenny Evitt
+tags: []
+---
+
+### PHP
+
+[Thierry Marianne](https://github.com/thierrymarianne) has contributed [a PHP plugin for Light Table](https://github.com/thierrymarianne/LightTable-PHP). Merci beaucoup Thierry!
+
+Version 0.0.1 currently supports _
+
+### Light Table 0.8.0 (alpha)
+
+It's been almost a year since the last significant release of Light Table but [we're finally nearing completion of the release of version 0.8.0 (alpha)](https://github.com/LightTable/LightTable/issues/1936).
+
+The major change is the migration from [node-webkit](http://nwjs.io/) (now NW.js) to [Atom Shell](http://electron.atom.io/) (now Electron).
+
+TODO: Write about other changes
+
+### The Future of Light Table
+
+The original core team at Kodowa has moved on to [another project](http://www.witheve.com/).
+
+TODO: Write something about the new core team
+
+TODO: Write something about what users can expect for ongoing development, i.e. contributions will consist of what contributors are willing to work on
+
+–Kenny


### PR DESCRIPTION
Contents:
1. The new PHP plugin
2. The upcoming v0.8.0 (alpha) release
3. Ongoing development of LT

For [2], we should also include some brief info about the v0.8.0 _stable_ release, e.g. an outline of the process for that to be completed.

For [3], I mainly wanted to describe the change in the core contributors and set expectations about ongoing development, e.g. that contributions will probably exclusively consist of changes contributors want to work on.
