### PR TITLE
Update download links to version 0.8.0.

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,9 @@
                 <div class="wrapper-downloads">
                     <p>ON WHICH PLATFORM WOULD YOU LIKE TO INSTALL LIGHT TABLE?</p>
                     <span class="platforms">
-                        <a href="https://github.com/LightTable/LightTable/releases/download/0.8.0-alpha/lighttable-0.8.0-alpha-windows.zip" class="windows"></a>
-                        <a href="https://github.com/LightTable/LightTable/releases/download/0.8.0-alpha/lighttable-0.8.0-alpha-mac.tar.gz" class="osx"></a>
-                        <a href="https://github.com/LightTable/LightTable/releases/download/0.8.0-alpha/lighttable-0.8.0-alpha-linux.tar.gz" class="linux64"></a>
+                        <a href="https://github.com/LightTable/LightTable/releases/download/0.8.0/lighttable-0.8.0-windows.zip" class="windows"></a>
+                        <a href="https://github.com/LightTable/LightTable/releases/download/0.8.0/lighttable-0.8.0-mac.tar.gz" class="osx"></a>
+                        <a href="https://github.com/LightTable/LightTable/releases/download/0.8.0/lighttable-0.8.0-linux.tar.gz" class="linux64"></a>
                     </span>
                 </div>
             </div>


### PR DESCRIPTION
For LightTable/LightTable#2064
