### PR TITLE
Update Gemfiles to point to gem server source - closes #18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+source 'https://rubygems.org'
 gem 'jekyll'
 gem 'albino'
 gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     albino (1.3.3)
       posix-spawn (>= 0.3.6)
@@ -46,4 +47,4 @@ DEPENDENCIES
   redcarpet
 
 BUNDLED WITH
-   1.10.6
+   1.12.5


### PR DESCRIPTION
For issue #18.

Adds `source 'https://rubygems.org'` to Gemfile. Also included Gemfile.lock as that seems to be something we do based on previous commits.
