### PR TITLE
Add API site link to header and footer - fixes #22

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
                     <ul>
                         <li><a href="https://github.com/LightTable/LightTable">SOURCE</a></li>
                         <li><a href="http://docs.lighttable.com">DOCS</a></li>
+                        <li><a href="http://lighttable.github.io/LightTable/api/">API</a></li>
                         <li><a href="https://groups.google.com/forum/#!forum/light-table-discussion">DISCUSSION</a></li>
                         <li><a href="http://www.lighttable.com/blog/">BLOG</a></li>
                         <li><a href="#" class="button download">DOWNLOAD</a></li>
@@ -237,6 +238,9 @@
                             <tr>
                                 <td class="leftlink"><a href="https://groups.google.com/forum/#!forum/light-table-discussion">DISCUSSION</a></td>
                                 <td class="rightlink"><a href="http://www.lighttable.com/blog/">BLOG</a></td>
+                            </tr>
+                            <tr>
+                                <td class="leftlink"><a href="http://lighttable.github.io/LightTable/api/">API</a></td>
                             </tr>
                         </table>
                         </li><!--


### PR DESCRIPTION
This PR adds a link for the API site to the header and footer of the main Light Table page for Issue #22 

As we should further expand and refine our API docs, I am fine with letting this PR linger. Otherwise, we could simply merge it. I am open to either path.